### PR TITLE
Fixed possible issue in Pak.cs

### DIFF
--- a/DanganPAKLib/Pak.cs
+++ b/DanganPAKLib/Pak.cs
@@ -153,5 +153,24 @@ namespace DanganPAKLib
             PakStream = stream;
             ReadHeader();
         }
+        public void Extract(string PAKPath, string OutPath = null)
+        {
+            Stream stream = new FileStream(PAKPath, FileMode.Open);
+            PakStream = stream;
+            ReadHeader();
+            string destination = "";
+
+            if (OutPath != null)
+            {
+                destination = OutPath;
+            }
+            else
+            {
+                destination = PAKPath + "_Extract_Pak";
+            }
+            //Directory.CreateDirectory(FolderPath);
+            ExtractAllFiles(OutPath + "/");
+            Dispose();
+        }
     }
 }

--- a/DanganPAKLib/Pak.cs
+++ b/DanganPAKLib/Pak.cs
@@ -65,7 +65,7 @@ namespace DanganPAKLib
             for (int i = 0; i < FileEntries.Count; i++)
             {
                 byte[] dat = GetFileData(i);
-                ExtractFile(i, Folder + i.ToString() + PakExtensionGuesser.GetMagicID(ref dat));
+                ExtractFile(i, Folder + i.ToString("D4") + PakExtensionGuesser.GetMagicID(ref dat));
             }
         }
         /*public static string PadNumbers(string input)
@@ -91,7 +91,8 @@ namespace DanganPAKLib
         }
         public static void Repack(string Folder, string OutPath = null)
         {
-            string[] files = Directory.GetFiles(Folder);
+            //string[] files = Directory.GetFiles(Folder);
+            string[] files = Directory.GetFiles(Folder).OrderBy(f => f).ToArray();
             var myComparer = new CustomComparer();
             List<string> temp = files.ToList();
             temp.Sort(myComparer);


### PR DESCRIPTION
Because of the way it works, sometimes when extracting the contents of the .Pak into a folder and then immediately trying to rebuild using the folder, it can sometimes cause some problems
This problem occurs because when rebuilding the .Pak it does not leave the files in the right order.